### PR TITLE
chore: remove dead code and fix variable shadowing in getBits

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -233,15 +233,6 @@ func (c *Cron) RemoveJobWithResult(name string) bool {
 	}
 }
 
-func (entrySlice entries) pos(name string) int {
-	for p, e := range entrySlice {
-		if e.Name == name {
-			return p
-		}
-	}
-	return -1
-}
-
 // Schedule adds a Job to the Cron to be run on the given schedule.
 func (c *Cron) Schedule(schedule Schedule, cmd Job, name string) {
 	c.ScheduleWithError(schedule, cmd, name)

--- a/issues_test.go
+++ b/issues_test.go
@@ -207,9 +207,9 @@ func TestCRIT3_Fixed_ZombieEntryBlocked(t *testing.T) {
 
 		entry := &Entry{
 			Schedule: fastSchedule{interval: 1 * time.Millisecond},
-			Job: wrapJobWithMetrics(FuncJob(func() {
+			Job: &SafeJob{Job: FuncJob(func() {
 				atomic.AddInt32(&execCount, 1)
-			}), "zombie", c.metrics),
+			}), Name: "zombie", metrics: c.metrics},
 			Name: "zombie-entry",
 		}
 

--- a/parser.go
+++ b/parser.go
@@ -142,16 +142,6 @@ func parseSpecWithError(spec string) (Schedule, error) {
 	return schedule, nil
 }
 
-// getField returns an Int with the bits set representing all of the times that
-// the field represents.  A "field" is a comma-separated list of "ranges".
-func getField(field string, r bounds) uint64 {
-	bits, err := getFieldWithError(field, r)
-	if err != nil {
-		log.Panic(err)
-	}
-	return bits
-}
-
 // getFieldWithError returns an Int with the bits set representing all of the times that
 // the field represents.  A "field" is a comma-separated list of "ranges".
 func getFieldWithError(field string, r bounds) (uint64, error) {
@@ -177,17 +167,6 @@ func getFieldWithError(field string, r bounds) (uint64, error) {
 		bits |= b
 	}
 	return bits, nil
-}
-
-// getRange returns the bits indicated by the given expression:
-//
-//	number | number "-" number [ "/" number ]
-func getRange(expr string, r bounds) uint64 {
-	bits, err := getRangeWithError(expr, r)
-	if err != nil {
-		log.Panic(err)
-	}
-	return bits
 }
 
 // getRangeWithError returns the bits indicated by the given expression:
@@ -306,11 +285,11 @@ func getBits(min, max, step uint) uint64 {
 
 	// If step is 1, use shifts.
 	if step == 1 {
-		bits := max - min + 1
-		if bits >= 64 {
+		span := max - min + 1
+		if span >= 64 {
 			return math.MaxUint64
 		}
-		return (uint64(1)<<bits - 1) << min
+		return (uint64(1)<<span - 1) << min
 	}
 
 	// Else, use a simple loop.

--- a/parser_test.go
+++ b/parser_test.go
@@ -30,7 +30,11 @@ func TestRange(t *testing.T) {
 	}
 
 	for _, c := range ranges {
-		actual := getRange(c.expr, bounds{c.min, c.max, nil})
+		actual, err := getRangeWithError(c.expr, bounds{c.min, c.max, nil})
+		if err != nil {
+			t.Errorf("%s => unexpected error %v", c.expr, err)
+			continue
+		}
 		if actual != c.expected {
 			t.Errorf("%s => (expected) %d != %d (actual)", c.expr, c.expected, actual)
 		}
@@ -50,7 +54,11 @@ func TestField(t *testing.T) {
 	}
 
 	for _, c := range fields {
-		actual := getField(c.expr, bounds{c.min, c.max, nil})
+		actual, err := getFieldWithError(c.expr, bounds{c.min, c.max, nil})
+		if err != nil {
+			t.Errorf("%s => unexpected error %v", c.expr, err)
+			continue
+		}
 		if actual != c.expected {
 			t.Errorf("%s => (expected) %d != %d (actual)", c.expr, c.expected, actual)
 		}

--- a/safe_job.go
+++ b/safe_job.go
@@ -38,11 +38,6 @@ func (s *SafeJob) Run() {
 	s.Job.Run()
 }
 
-// wrapJobWithMetrics wraps a job with panic recovery and metrics
-func wrapJobWithMetrics(job Job, name string, metrics *Metrics) Job {
-	return &SafeJob{Job: job, Name: name, metrics: metrics}
-}
-
 var (
 	testModeOnce   sync.Once
 	testModeCached bool


### PR DESCRIPTION
Resolves GOC-29: remove library dead code and fix the `bits` variable shadowing in `getBits`.

## Changes

- **parser.go**: removed the unused panic-wrapper functions `getField` and `getRange` (no library call sites; only tests referenced them). Tests now call `getFieldWithError` / `getRangeWithError` directly and assert no error.
- **safe_job.go**: removed the unused `wrapJobWithMetrics` helper; the single test that used it now constructs `&SafeJob{...}` directly (the library itself already initializes the embedded `SafeJob` inline in `ScheduleWithError`).
- **cron.go**: removed the completely unreferenced `entries.pos` method.
- **parser.go `getBits`**: renamed the inner `bits := max - min + 1` to `span`, eliminating the shadowing of the outer `bits`. Current behavior is unchanged (max bounds span is 60, so the `>= 64` branch never fires today), but this removes the latent hazard where a future bounds expansion would return `math.MaxUint64` with the `starBit` position implicitly set.

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all tests pass (33s full suite)
