### PR TITLE
fix: Stop/Start lifecycle corner cases (stale fire buffer + doubled StopAndWait timeout)

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -311,6 +311,10 @@ func (c *Cron) Start() {
 		return
 	}
 	c.done = make(chan struct{})
+	// Recreate the fire channel so stale messages buffered during a previous
+	// run (a timer callback may win the select race against <-c.done) can
+	// never be consumed by the new run() and trigger an immediate extra run.
+	c.fire = make(chan *Entry, 64)
 	atomic.StoreInt32(&c.running, 1)
 	c.mu.Unlock()
 	go c.run()
@@ -421,11 +425,15 @@ func (c *Cron) scheduleEntry(e *Entry) {
 		duration = 0
 	}
 
+	// Capture the channels of the current run: Start() replaces both, so a
+	// late callback from a previous run writes to the old (unread) channel
+	// instead of injecting a stale fire into the new run.
+	fire, done := c.fire, c.done
 	e.timer = time.AfterFunc(duration, func() {
 		// Timer 回调只发信号，不做任何 Entry 修改
 		select {
-		case c.fire <- e:
-		case <-c.done:
+		case fire <- e:
+		case <-done:
 			// run() 已退出，丢弃
 		}
 	})
@@ -468,8 +476,11 @@ func (c *Cron) StopWithTimeout(timeout time.Duration) error {
 }
 
 // StopAndWait stops the cron scheduler and waits for all running jobs to complete.
+// The timeout is a single budget shared by both phases (stopping the scheduler
+// and waiting for running jobs), so the total wait never exceeds it.
 // Returns error if timeout is exceeded.
 func (c *Cron) StopAndWait(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
 	if err := c.StopWithTimeout(timeout); err != nil {
 		return err
 	}
@@ -480,10 +491,12 @@ func (c *Cron) StopAndWait(timeout time.Duration) error {
 		close(done)
 	}()
 
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
 	select {
 	case <-done:
 		return nil
-	case <-time.After(timeout):
+	case <-timer.C:
 		return errors.New("cron: wait timeout exceeded")
 	}
 }

--- a/issues_test.go
+++ b/issues_test.go
@@ -650,3 +650,75 @@ func TestRemoveJobWithResult_Fixed_ReturnsFalseForNonExistent(t *testing.T) {
 // =============================================================================
 // Extra: wrapJob 死代码已移除（不再有测试）
 // =============================================================================
+
+// =============================================================================
+// GOC-25 [已修复]: Stop/Start 生命周期边角
+// (a) fire 缓冲残留: Stop 后残留在 fire 缓冲中的消息不应被下次 Start 消费
+// (b) StopAndWait 超时翻倍: 两步共享一个 deadline，总等待不超过 timeout
+// =============================================================================
+
+func TestGOC25a_StaleFireNotConsumedAfterRestart(t *testing.T) {
+	c := New()
+	var runs int32
+	// 调度时间远在未来，正常情况下不会触发
+	c.AddFunc("0 0 1 1 *", func() {
+		atomic.AddInt32(&runs, 1)
+	}, "far-future-job")
+
+	c.Start()
+	staleFire := c.fire // 第一次运行的 fire channel
+	c.Stop()
+
+	// 模拟 timer 回调在 select 竞态中赢过 <-c.done，把 entry 残留进缓冲
+	c.mu.Lock()
+	entry := c.entryIndex["far-future-job"]
+	c.mu.Unlock()
+	staleFire <- entry
+
+	// 重启后新 run() 不应消费旧缓冲中的陈旧消息
+	c.Start()
+	time.Sleep(200 * time.Millisecond)
+	c.Stop()
+
+	if got := atomic.LoadInt32(&runs); got != 0 {
+		t.Fatalf("GOC-25(a): 重启后陈旧的 fire 消息被消费，任务多跑了 %d 次", got)
+	}
+	t.Log("GOC-25(a) [已修复]: Start() 重建 fire channel，陈旧消息不会触发额外执行")
+}
+
+func TestGOC25b_StopAndWaitSharedDeadline(t *testing.T) {
+	c := New()
+	jobStarted := make(chan struct{})
+	started := int32(0)
+
+	c.AddFunc("* * * * * *", func() {
+		if atomic.CompareAndSwapInt32(&started, 0, 1) {
+			close(jobStarted)
+		}
+		time.Sleep(10 * time.Second)
+	}, "goc25-long-job")
+
+	c.Start()
+
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		c.Stop()
+		t.Skip("GOC-25(b): Job 未在 2 秒内启动")
+		return
+	}
+
+	timeout := 500 * time.Millisecond
+	startTime := time.Now()
+	err := c.StopAndWait(timeout)
+	elapsed := time.Since(startTime)
+
+	if err == nil {
+		t.Fatal("GOC-25(b): 存在 10s 长任务时 StopAndWait(500ms) 应返回超时错误")
+	}
+	// 两步共享 deadline: 总耗时应约等于 timeout，而不是最坏 2*timeout
+	if elapsed > timeout+300*time.Millisecond {
+		t.Fatalf("GOC-25(b): StopAndWait 总耗时 %v 超过共享 deadline 预期（timeout=%v）", elapsed, timeout)
+	}
+	t.Logf("GOC-25(b) [已修复]: StopAndWait 总耗时 %v（timeout=%v，两步共享 deadline）", elapsed, timeout)
+}


### PR DESCRIPTION
Fixes the two Stop/Start lifecycle corner cases reported in GOC-25.

## (a) Stale `fire` buffer residue

The timer callback selects between `c.fire <- e` and `<-c.done`. When `done` is closed and the buffered `fire` channel (cap 64) has free space, **both branches are ready and Go picks one at random**, so a stale entry can land in the buffer. A message can also land there legitimately in the instant before stop closes `done`. Since `Start()` recreated `done` but not `fire`, the next `run()` (which resets `cancelled = false` and rebuilds timers) consumed the stale message → the job ran immediately on restart and `Next` was advanced a second time.

**Fix:**
- `Start()` now recreates the `fire` channel together with `done`, so anything buffered during a previous run is unreachable to the new `run()`.
- `scheduleEntry` captures the current run's `fire`/`done` channels at timer-creation time, so a late callback from a previous run writes to the old, unread channel instead of injecting a stale fire into the new run.

## (b) `StopAndWait` doubled timeout

`StopAndWait(timeout)` spent up to `timeout` inside `StopWithTimeout`, then waited up to a **fresh** `timeout` for `workerPool.Wait()` — worst case 2×timeout total.

**Fix:** both phases now share a single deadline computed on entry, so the total wait never exceeds `timeout`.

## Tests

- `TestGOC25a_StaleFireNotConsumedAfterRestart` — injects a stale entry into the previous run's fire buffer and verifies a restart does not execute it. **Fails against the previous code** (job runs 1 extra time), passes with the fix.
- `TestGOC25b_StopAndWaitSharedDeadline` — with a 10s job running, `StopAndWait(500ms)` returns a timeout error in ~timeout total, not 2×.

Full suite passes (`go test .`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
