### PR TITLE
fix: drain and clear pooled request before returning to pool (GOC-21)

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -37,6 +37,27 @@ var removeReqPool = sync.Pool{
 	},
 }
 
+// putAddReq 归还请求对象前先非阻塞排空 result 缓冲(避免调用方在 <-done 分支返回时
+// 把 run() 已写入的结果残留进池,导致下一个复用者脏读),并清空 entry 引用避免池长期持有。
+func putAddReq(req *addRequest) {
+	select {
+	case <-req.result:
+	default:
+	}
+	req.entry = nil
+	addReqPool.Put(req)
+}
+
+// putRemoveReq 同 putAddReq:归还前排空 result 缓冲并清空 name。
+func putRemoveReq(req *removeRequest) {
+	select {
+	case <-req.result:
+	default:
+	}
+	req.name = ""
+	removeReqPool.Put(req)
+}
+
 // Cron keeps track of any number of entries, invoking the associated func as
 // specified by the schedule. It may be started, stopped, and the entries may
 // be inspected while running.
@@ -235,14 +256,14 @@ func (c *Cron) RemoveJobWithResult(name string) bool {
 	case c.remove <- *req:
 		select {
 		case r := <-req.result:
-			removeReqPool.Put(req)
+			putRemoveReq(req)
 			return r
 		case <-done:
-			removeReqPool.Put(req)
+			putRemoveReq(req)
 			return false
 		}
 	case <-done:
-		removeReqPool.Put(req)
+		putRemoveReq(req)
 		return false
 	}
 }
@@ -289,14 +310,14 @@ func (c *Cron) ScheduleWithError(schedule Schedule, cmd Job, name string) error 
 	case c.add <- *req:
 		select {
 		case err := <-req.result:
-			addReqPool.Put(req)
+			putAddReq(req)
 			return err
 		case <-done:
-			addReqPool.Put(req)
+			putAddReq(req)
 			return errors.New("cron: scheduler stopped")
 		}
 	case <-done:
-		addReqPool.Put(req)
+		putAddReq(req)
 		return errors.New("cron: scheduler stopped")
 	}
 }

--- a/cron_goc21_test.go
+++ b/cron_goc21_test.go
@@ -1,0 +1,97 @@
+package cron
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// GOC-21: 请求对象经 sync.Pool 复用,result 是容量 1 的带缓冲 channel。若调用方在
+// <-done 分支返回,而 run() 已把结果写入 result,直接 Put 会把带残留值的对象放回池,
+// 下一个复用者会脏读到上一次的结果。putAddReq/putRemoveReq 必须在归还前排空缓冲、清引用。
+
+func TestGOC21_PutAddReqDrainsAndClears(t *testing.T) {
+	req := &addRequest{result: make(chan error, 1)}
+	req.entry = &Entry{Name: "stale"}
+	// 模拟 run() 已写入结果、但调用方走了 <-done 分支未消费
+	req.result <- errors.New("stale error")
+
+	putAddReq(req)
+
+	if len(req.result) != 0 {
+		t.Errorf("putAddReq 未排空 result 缓冲,残留 %d 个值(下一个复用者会脏读)", len(req.result))
+	}
+	if req.entry != nil {
+		t.Error("putAddReq 未清空 entry 引用(池会长期持有 Entry)")
+	}
+}
+
+func TestGOC21_PutRemoveReqDrainsAndClears(t *testing.T) {
+	req := &removeRequest{result: make(chan bool, 1)}
+	req.name = "stale"
+	req.result <- true // 模拟残留的"成功"结果
+
+	putRemoveReq(req)
+
+	if len(req.result) != 0 {
+		t.Errorf("putRemoveReq 未排空 result 缓冲,残留 %d 个值", len(req.result))
+	}
+	if req.name != "" {
+		t.Error("putRemoveReq 未清空 name")
+	}
+}
+
+// 集成回归:并发添加(唯一名)与 Start/Stop 交错时,凡是 AddFuncWithError 返回 nil 的任务
+// 都必须真实存在。GOC-21 修复前,脏读会让某些 add 读到陈旧的 nil 而误报成功(实则未添加)。
+func TestGOC21_NoFalseSuccessUnderChurn(t *testing.T) {
+	c := New()
+
+	const workers = 100
+	added := make([]int32, workers)
+
+	stopCycle := make(chan struct{})
+	var cycler sync.WaitGroup
+	cycler.Add(1)
+	go func() {
+		defer cycler.Done()
+		for {
+			select {
+			case <-stopCycle:
+				return
+			default:
+			}
+			c.Start()
+			c.Stop()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			if err := c.AddFuncWithError("0 0 1 1 *", func() {}, fmt.Sprintf("job-%d", id)); err == nil {
+				atomic.StoreInt32(&added[id], 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	close(stopCycle)
+	cycler.Wait()
+	c.Stop()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id := 0; id < workers; id++ {
+		if atomic.LoadInt32(&added[id]) != 1 {
+			continue
+		}
+		name := fmt.Sprintf("job-%d", id)
+		if _, ok := c.entryIndex[name]; !ok {
+			t.Errorf("%s 报告添加成功,却不存在(脏读误报成功 / 静默丢失)", name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the `sync.Pool` dirty-result reuse in the add/remove channel paths (Refs GOC-21).

## Problem

`addRequest`/`removeRequest` objects are reused via `sync.Pool`, and each has a **buffered (cap 1)** `result` channel. When `c.add <- *req` (or `c.remove <- *req`) succeeds, `run()` writes `req.result` and then — on a later select iteration — may close `done`. If the caller's inner `select` then picks the `<-done` branch, it returns and `Put`s the request back to the pool **with a value still buffered**. The next `Get` of that object reads the stale `error`/`bool` as if it were its own result → false success/failure.

## Fix

Add `putAddReq` / `putRemoveReq` helpers used at every `Put` site. Before returning to the pool they:
- non-blocking drain the `result` channel (`select { case <-req.result: default: }`), and
- clear `entry` / `name` so the pool doesn't retain an `Entry` reference.

No public API or behavior change for callers.

## Tests

- `TestGOC21_PutAddReqDrainsAndClears` / `TestGOC21_PutRemoveReqDrainsAndClears` — deterministic: seed a stale value + set the field, call the helper, assert the buffer is drained and the field cleared. These fail if the drain logic is removed.
- `TestGOC21_NoFalseSuccessUnderChurn` — `-race` churn test: concurrent adds while `Start()`/`Stop()` cycle, asserting every add that reports success is actually present.

## Verification

`go build ./...`, `go vet ./...`, `gofmt` clean, and the **full suite under `go test -race ./...`** pass locally (this repo has no CI, so the local race run is the gate). Builds on the GOC-22 fix (#5) already on master.
