### PR TITLE
fix: bound worker-pool goroutines with admission control + drop metric (GOC-23)

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -553,6 +553,7 @@ func (c *Cron) GetMetrics() Metrics {
 		TotalRuns:   atomic.LoadInt64(&c.metrics.TotalRuns),
 		TotalPanics: atomic.LoadInt64(&c.metrics.TotalPanics),
 		ActiveJobs:  atomic.LoadInt32(&c.metrics.ActiveJobs),
+		DroppedJobs: c.workerPool.Dropped(),
 	}
 }
 

--- a/cron_goc23_test.go
+++ b/cron_goc23_test.go
@@ -1,0 +1,102 @@
+package cron
+
+import (
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
+
+// GOC-23: 旧实现每次 Submit 都无条件新建 goroutine、在 goroutine 内才抢信号量,
+// 等待信号量的 goroutine 会无界堆积。现在 Submit 有准入上限(maxInFlight),
+// 超过即丢弃并计数,in-flight goroutine 数被硬性限制。
+
+// Submit 达到 in-flight 上限后必须丢弃并计数,而不是继续新建 goroutine。
+// inFlight 计数在 Submit 内同步自增,因此本用例是确定性的,不依赖调度时序。
+func TestGOC23_SubmitDropsWhenSaturated(t *testing.T) {
+	// 并发上限 1,in-flight 上限 3。
+	wp := NewWorkerPoolWithQueue(1, 3)
+
+	block := make(chan struct{})
+	// 3 个任务占满 in-flight(1 个执行、2 个等待信号量),全部阻塞在 block 上。
+	for i := 0; i < 3; i++ {
+		wp.Submit(func() { <-block })
+	}
+	if got := wp.Pending(); got != 3 {
+		t.Fatalf("占满后 Pending 应为 3,实际 %d", got)
+	}
+
+	// 再提交 5 个:已达上限,必须全部被丢弃(其函数体不得执行)。
+	for i := 0; i < 5; i++ {
+		wp.Submit(func() { t.Error("被丢弃的任务不应执行") })
+	}
+	if got := wp.Dropped(); got != 5 {
+		t.Fatalf("期望丢弃 5,实际 %d", got)
+	}
+	if got := wp.Pending(); got != 3 {
+		t.Fatalf("丢弃不应改变 in-flight,Pending 应仍为 3,实际 %d", got)
+	}
+	if got := wp.Running(); got > 1 {
+		t.Fatalf("并发执行数不得超过 1,实际 %d", got)
+	}
+
+	// 放行后 3 个被接收的任务全部完成,in-flight 归零,丢弃计数不变。
+	close(block)
+	wp.Wait()
+	if got := wp.Pending(); got != 0 {
+		t.Fatalf("全部完成后 Pending 应为 0,实际 %d", got)
+	}
+	if got := wp.Dropped(); got != 5 {
+		t.Fatalf("完成后丢弃计数应仍为 5,实际 %d", got)
+	}
+}
+
+// in-flight 上限之内的突发(远大于并发上限)必须全部执行、不丢弃——保持旧的
+// "所有提交最终都会运行"语义,仅并发受限。
+func TestGOC23_BurstWithinCapAllRun(t *testing.T) {
+	wp := NewWorkerPoolWithQueue(4, 200)
+
+	const jobs = 150 // > 并发上限,但 < in-flight 上限
+	var ran int32
+	for i := 0; i < jobs; i++ {
+		wp.Submit(func() { atomic.AddInt32(&ran, 1) })
+	}
+	wp.Wait()
+
+	if got := atomic.LoadInt32(&ran); got != jobs {
+		t.Fatalf("上限内的突发应全部执行:期望 %d,实际 %d", jobs, got)
+	}
+	if got := wp.Dropped(); got != 0 {
+		t.Fatalf("上限内不应丢弃,实际丢弃 %d", got)
+	}
+}
+
+// 默认池:并发上限 = NumCPU*128,in-flight 上限 = 并发上限 * defaultQueueFactor。
+func TestGOC23_DefaultCaps(t *testing.T) {
+	wp := NewWorkerPool(0)
+	wantConc := runtime.NumCPU() * 128
+	if cap(wp.semaphore) != wantConc {
+		t.Fatalf("默认并发上限应为 %d,实际 %d", wantConc, cap(wp.semaphore))
+	}
+	if int(wp.maxInFlight) != wantConc*defaultQueueFactor {
+		t.Fatalf("默认 in-flight 上限应为 %d,实际 %d", wantConc*defaultQueueFactor, wp.maxInFlight)
+	}
+}
+
+// GetMetrics 应暴露饱和度指标 DroppedJobs。
+func TestGOC23_MetricsExposeDropped(t *testing.T) {
+	c := NewWithWorkerLimit(1)
+	// 直接压满其 worker pool 以产生丢弃(不依赖调度时序)。
+	block := make(chan struct{})
+	wp := c.workerPool
+	limit := int(wp.maxInFlight)
+	for i := 0; i < limit; i++ {
+		wp.Submit(func() { <-block })
+	}
+	wp.Submit(func() { t.Error("应被丢弃") }) // 第 limit+1 个:丢弃
+
+	if got := c.GetMetrics().DroppedJobs; got != 1 {
+		t.Fatalf("GetMetrics().DroppedJobs 应为 1,实际 %d", got)
+	}
+	close(block)
+	wp.Wait()
+}

--- a/metrics.go
+++ b/metrics.go
@@ -7,6 +7,10 @@ type Metrics struct {
 	TotalRuns   int64
 	TotalPanics int64
 	ActiveJobs  int32
+	// DroppedJobs is the number of fires dropped because the worker pool was
+	// saturated (jobs firing faster than they can run). Non-zero indicates the
+	// scheduler is overloaded.
+	DroppedJobs int64
 }
 
 func (m *Metrics) incRuns() {

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -3,40 +3,88 @@ package cron
 import (
 	"runtime"
 	"sync"
+	"sync/atomic"
 )
 
-// WorkerPool manages concurrent job execution
+// defaultQueueFactor bounds how many goroutines may be waiting for an execution
+// slot, as a multiple of the concurrency limit. Without this bound a scheduler
+// that fires faster than its jobs complete spawns a goroutine per fire that
+// blocks on the semaphore, growing without limit until the process OOMs.
+const defaultQueueFactor = 16
+
+// WorkerPool manages concurrent job execution with a bounded number of
+// in-flight goroutines.
 type WorkerPool struct {
-	semaphore chan struct{}
-	wg        sync.WaitGroup
+	semaphore   chan struct{} // limits concurrent execution
+	maxInFlight int32         // hard cap on spawned goroutines (waiting + running)
+	inFlight    int32         // atomic: goroutines currently spawned
+	dropped     int64         // atomic: jobs dropped because the pool was saturated
+	wg          sync.WaitGroup
 }
 
-// NewWorkerPool creates a worker pool with specified max workers.
-// If maxWorkers <= 0, a default cap of runtime.NumCPU() * 128 is used.
+// NewWorkerPool creates a worker pool with the specified max concurrent workers.
+// If maxWorkers <= 0, a default of runtime.NumCPU() * 128 is used. The number of
+// in-flight goroutines is bounded to maxWorkers * defaultQueueFactor.
 func NewWorkerPool(maxWorkers int) *WorkerPool {
 	if maxWorkers <= 0 {
 		maxWorkers = runtime.NumCPU() * 128
 	}
+	return NewWorkerPoolWithQueue(maxWorkers, maxWorkers*defaultQueueFactor)
+}
+
+// NewWorkerPoolWithQueue creates a worker pool with an explicit concurrency limit
+// (maxWorkers) and an explicit cap on total in-flight goroutines (maxInFlight).
+// maxInFlight is raised to at least maxWorkers. When the cap is reached, further
+// Submit calls drop the job (non-blocking) and increment Dropped(), instead of
+// spawning yet another goroutine that would pile up without bound.
+func NewWorkerPoolWithQueue(maxWorkers, maxInFlight int) *WorkerPool {
+	if maxWorkers <= 0 {
+		maxWorkers = runtime.NumCPU() * 128
+	}
+	if maxInFlight < maxWorkers {
+		maxInFlight = maxWorkers
+	}
 	return &WorkerPool{
-		semaphore: make(chan struct{}, maxWorkers),
+		semaphore:   make(chan struct{}, maxWorkers),
+		maxInFlight: int32(maxInFlight),
 	}
 }
 
-// Submit submits a job to the worker pool.
-// The semaphore acquisition happens inside the goroutine so that the caller
-// (the scheduler's run() loop) is never blocked by a saturated pool.
+// Submit runs job on the pool. It never blocks the caller (the scheduler's run()
+// loop): if the pool is already at its in-flight cap, the job is dropped and
+// counted rather than spawning another goroutine. Concurrency of actually
+// executing jobs is still limited to maxWorkers by the semaphore.
 func (wp *WorkerPool) Submit(job func()) {
-	wp.wg.Add(1)
+	// Admission control: reserve an in-flight slot up front. Exceeding the cap
+	// means jobs are firing faster than they can run; drop rather than grow
+	// waiting goroutines without bound.
+	if atomic.AddInt32(&wp.inFlight, 1) > wp.maxInFlight {
+		atomic.AddInt32(&wp.inFlight, -1)
+		atomic.AddInt64(&wp.dropped, 1)
+		return
+	}
 
+	wp.wg.Add(1)
 	go func() {
-		wp.semaphore <- struct{}{} // acquire slot inside goroutine
 		defer wp.wg.Done()
+		defer atomic.AddInt32(&wp.inFlight, -1)
+		wp.semaphore <- struct{}{} // acquire execution slot
 		defer func() { <-wp.semaphore }()
 		job()
 	}()
 }
 
-// Wait waits for all jobs to complete
+// Wait waits for all accepted jobs to complete.
 func (wp *WorkerPool) Wait() {
 	wp.wg.Wait()
 }
+
+// Running returns the number of jobs currently executing.
+func (wp *WorkerPool) Running() int { return len(wp.semaphore) }
+
+// Pending returns the number of in-flight goroutines (waiting for a slot plus
+// currently executing).
+func (wp *WorkerPool) Pending() int { return int(atomic.LoadInt32(&wp.inFlight)) }
+
+// Dropped returns the total number of jobs dropped because the pool was saturated.
+func (wp *WorkerPool) Dropped() int64 { return atomic.LoadInt64(&wp.dropped) }


### PR DESCRIPTION
Bounds the worker pool's goroutine growth under sustained overload (Refs GOC-23).

## Problem

`Submit` spawned a goroutine for every fire and only acquired the semaphore **inside** that goroutine:

```go
func (wp *WorkerPool) Submit(job func()) {
    wp.wg.Add(1)
    go func() {
        wp.semaphore <- struct{}{} // acquire slot *inside* the goroutine
        ...
```

The semaphore limited concurrent *execution*, not the number of *spawned* goroutines. When jobs run slower than they fire, the goroutines blocked on the semaphore grow without bound (each ~2–8KB) until the process OOMs. `TestCRIT4_Fixed_GoroutinesBounded` only held because its jobs finished quickly.

## Fix

Add **admission control**: cap total in-flight goroutines (waiting + running) at `maxWorkers * 16` (or an explicit value via the new `NewWorkerPoolWithQueue`). The in-flight count is reserved synchronously in `Submit`; if it would exceed the cap, the fire is **dropped and counted** instead of spawning another goroutine.

Why drop rather than block: `Submit` is called from the scheduler's `run()` loop, which must never block — and blocking it would just move the unbounded growth to the timer callbacks (each `time.AfterFunc` callback would then pile up on the full `fire` channel). Dropping is the only policy that truly bounds goroutines without stalling the scheduler. Concurrency of executing jobs is still limited to `maxWorkers`.

Expose saturation metrics: `WorkerPool.Running()/Pending()/Dropped()` and a new `Metrics.DroppedJobs` surfaced through `GetMetrics()`.

## Compatibility

The cap (16× the concurrency limit) is far above any realistic burst, so behavior is **unchanged for normal load** and every existing pool test passes **unmodified** (`TestCRIT4_*`, `TestGuard_WorkerPool_*`). Drops only happen under sustained overload — the exact scenario that previously headed toward OOM. `NewWorkerPool` / `NewWithWorkerLimit` signatures are unchanged.

## Tests

- `TestGOC23_SubmitDropsWhenSaturated` — deterministic: fill the in-flight cap with blocked jobs, then further submits are dropped (their bodies never run) and `Dropped()` counts them; `Pending()` stays capped; `Running() ≤ maxWorkers`.
- `TestGOC23_BurstWithinCapAllRun` — a burst well above the concurrency limit but within the cap runs every job, zero drops.
- `TestGOC23_DefaultCaps`, `TestGOC23_MetricsExposeDropped`.

## Verification

`go build`, `go vet`, `gofmt` clean, and the **full suite under `go test -race ./...`** pass locally (repo has no CI). Builds on GOC-22 (#5) and GOC-21 (#6).
