### PR TITLE
fix: compute next fire from now to avoid catch-up storm (GOC-20)

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -429,10 +429,7 @@ func (c *Cron) run() {
 				break
 			}
 			// 所有 Entry 修改都在 run() goroutine 中完成
-			c.workerPool.Submit(e.Job.Run)
-			e.Prev = e.Next
-			e.Next = e.Schedule.Next(e.Next)
-			c.scheduleEntry(e)
+			c.advanceAndReschedule(e, time.Now().Local())
 
 		case <-c.snapshot:
 			c.snapshot <- c.entrySnapshot()
@@ -450,6 +447,22 @@ func (c *Cron) run() {
 			return
 		}
 	}
+}
+
+// advanceAndReschedule runs the fired entry's job, records the fire, and re-arms
+// the timer for the NEXT activation computed from `now`.
+//
+// Computing the next time from `now` (rather than from the entry's stale
+// scheduled time) skips any activations missed while the process was frozen
+// (laptop sleep, container pause, long GC/STW). Advancing from the stale time
+// would return past times that scheduleEntry clamps to a zero delay, firing
+// every missed slot back-to-back — a "catch-up storm". This matches robfig/cron.
+func (c *Cron) advanceAndReschedule(e *Entry, now time.Time) {
+	// 所有 Entry 修改都在 run() goroutine 中完成
+	c.workerPool.Submit(e.Job.Run)
+	e.Prev = e.Next
+	e.Next = e.Schedule.Next(now)
+	c.scheduleEntry(e)
 }
 
 // scheduleEntry creates a timer for the entry (优化: 独立Timer调度)

--- a/cron_goc20_test.go
+++ b/cron_goc20_test.go
@@ -1,0 +1,72 @@
+package cron
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// GOC-20: fire 分支原先用"上一次计划时间"推算下一次(Next(e.Next))。进程冻结
+// (休眠/容器暂停/长 GC-STW)恢复后,错过的触发点会因 scheduleEntry 把负 duration
+// 钳为 0 而背靠背连续补跑——追赶风暴。修复后从 now 推算,跳过错过的触发。
+func TestGOC20_MissedFiresSkippedNoCatchUpStorm(t *testing.T) {
+	c := New()
+
+	var runs int32
+	e := &Entry{
+		Schedule: ConstantDelaySchedule{Delay: time.Second},
+		Name:     "every-1s",
+		Job:      FuncJob(func() { atomic.AddInt32(&runs, 1) }),
+	}
+	// 模拟进程冻结约 60s:上一次计划时间远在过去。
+	past := time.Now().Add(-60 * time.Second)
+	e.Next = past
+
+	now := time.Now()
+	c.advanceAndReschedule(e, now)
+
+	// 关键不变式:下一次触发必须落在未来(跳过错过的 ~60 次),
+	// 而不是停留在过去 → duration 被钳为 0 → 立即反复补跑。
+	if !e.Next.After(now) {
+		t.Fatalf("追赶风暴未修复:下一次触发 %v 不在 now %v 之后", e.Next, now)
+	}
+	// 且应落在下一个间隔内(约 1s),而非累积到过去。
+	if d := e.Next.Sub(now); d <= 0 || d > 2*time.Second {
+		t.Fatalf("下一次触发时延异常:%v(应约为一个间隔)", d)
+	}
+	// Prev 记录本次(错过的)计划时间。
+	if !e.Prev.Equal(past) {
+		t.Errorf("Prev 应记录本次计划时间 %v,实际 %v", past, e.Prev)
+	}
+
+	// 单次 fire 只提交一次任务。
+	c.workerPool.Wait()
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("单次 fire 应只执行一次,实际 %d", got)
+	}
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
+	// 前提说明:旧逻辑 Next(past) 仍在过去,正是它导致 0 delay 风暴。
+	if e.Schedule.Next(past).After(now) {
+		t.Fatal("测试前提失效:Next(past) 不应在 now 之后")
+	}
+}
+
+// 正常节奏不受影响:每秒任务在 ~2.5s 内应触发 2~3 次,而非因风暴狂跑。
+func TestGOC20_NormalCadenceUnaffected(t *testing.T) {
+	c := New()
+	var runs int32
+	if err := c.AddFuncWithError("@every 1s", func() { atomic.AddInt32(&runs, 1) }, "cadence"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	c.Start()
+	time.Sleep(2500 * time.Millisecond)
+	c.Stop()
+
+	got := atomic.LoadInt32(&runs)
+	if got < 1 || got > 5 {
+		t.Fatalf("每秒任务 2.5s 内应触发约 2~3 次,实际 %d(过多可能是追赶风暴)", got)
+	}
+}


### PR DESCRIPTION
Avoids the catch-up storm after a process freeze (Refs GOC-20).

## Problem

The fire branch advanced the schedule from the entry's **stale scheduled time**:

```go
e.Next = e.Schedule.Next(e.Next)
```

Combined with `scheduleEntry` clamping negative delays to `0`, a process freeze (laptop sleep, container pause, long GC/STW) made every missed activation fire back-to-back on resume. Example: an `@every 1s` job paused for 60s immediately fires **60 times** the instant it resumes.

## Fix

Advance from `now` instead:

```go
e.Next = e.Schedule.Next(time.Now())
```

This skips the missed activations and lands the next fire in the future — the same behavior as robfig/cron. Extracted `advanceAndReschedule(e, now)` (same operations: submit, record Prev, recompute Next, re-arm timer) so the logic is unit-testable.

Default is now **skip** (fire once on resume, then resume normal cadence). A configurable misfire policy (skip / fire-once / catch-up) could be layered on later if a use case needs catch-up.

## Compatibility

For on-time fires `now ≈ e.Next`, so `Next(now)` equals the old `Next(e.Next)` — no change to normal cadence. Only the freeze/overload case differs (skip instead of storm). Full existing suite passes unmodified.

## Tests

- `TestGOC20_MissedFiresSkippedNoCatchUpStorm` — deterministic: a fire whose `Next` is 60s stale reschedules into the **future** (within one interval), runs the job exactly once, and records `Prev`. (On the old logic the next time stays in the past, which is what drove the 0-delay storm.)
- `TestGOC20_NormalCadenceUnaffected` — an `@every 1s` job fires ~2–3× over 2.5s, not a burst.

## Verification

`go build`, `go vet`, `gofmt` clean, and the **full suite under `go test -race ./...`** pass locally (repo has no CI). Completes the cron concurrency/correctness batch after #5 (GOC-22), #6 (GOC-21), #7 (GOC-23).
